### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -116,7 +116,7 @@ def generate_test_methods(cls, stream):
                 mname = "test_" + mname
 
             # Include parameters in attribute name
-            name = "%s(%s)" % (mname, ", ".join(args))
+            name = "{0!s}({1!s})".format(mname, ", ".join(args))
             setattr(cls, name, wrapper)
 
         # Remove the generator afterwards, it did its work
@@ -273,7 +273,7 @@ class TestContainer(object):
     def _test_indentation(self, filename, contents):
         for i, line in enumerate(contents.splitlines()):
             self.assertRegex(line, r"^\t*\S",
-                             "Indent must be tabs in line %d" % (i + 1))
+                             "Indent must be tabs in line {0:d}".format((i + 1)))
 
     package_key_types_map = {
         'name': str_cls,
@@ -517,7 +517,7 @@ class TestContainer(object):
                 self.assertRegex(v, r'(?i)^[0-9a-f]{64}$')
 
     def enforce_key_types_map(self, k, v, key_types_map):
-        self.assertIn(k, key_types_map, 'Unknown key "%s"' % k)
+        self.assertIn(k, key_types_map, 'Unknown key "{0!s}"'.format(k))
         self.assertIsInstance(v, key_types_map[k], k)
 
         if (
@@ -543,9 +543,9 @@ class TestContainer(object):
 
         if e:
             if isinstance(e, HTTPError):
-                self.fail("%s: %s" % (msg, e))
+                self.fail("{0!s}: {1!s}".format(msg, e))
             else:
-                self.fail("%s: %r" % (msg, e))
+                self.fail("{0!s}: {1!r}".format(msg, e))
         else:
             self.fail(msg)
 
@@ -567,7 +567,7 @@ class TestContainer(object):
             and .flush()
         """
         # TODO multi-threading
-        stream.write("%s ... " % path)
+        stream.write("{0!s} ... ".format(path))
         stream.flush()
 
         success = False
@@ -579,7 +579,7 @@ class TestContainer(object):
                     source = f.read()
                     f.close()
                 except Exception as e:
-                    yield cls._fail("Downloading %s failed" % path, e)
+                    yield cls._fail("Downloading {0!s} failed".format(path), e)
                     return
                 source = source.decode("utf-8", 'strict')
             else:
@@ -587,37 +587,35 @@ class TestContainer(object):
                     with _open(path) as f:
                         source = f.read().decode('utf-8', 'strict')
                 except Exception as e:
-                    yield cls._fail("Opening %s failed" % path, e)
+                    yield cls._fail("Opening {0!s} failed".format(path), e)
                     return
 
             if not source:
-                yield cls._fail("%s is empty" % path)
+                yield cls._fail("{0!s} is empty".format(path))
                 return
 
             # Parse the repository
             try:
                 data = json.loads(source)
             except Exception as e:
-                yield cls._fail("Could not parse %s" % path, e)
+                yield cls._fail("Could not parse {0!s}".format(path), e)
                 return
 
             # Check for the schema version first (and generator failures it's
             # badly formatted)
             if 'schema_version' not in data:
-                yield cls._fail("No schema_version found in %s" % path)
+                yield cls._fail("No schema_version found in {0!s}".format(path))
                 return
             schema = data['schema_version']
             if schema != '3.0.0' and float(schema) not in (1.0, 1.1, 1.2, 2.0):
-                yield cls._fail("Unrecognized schema version %s in %s"
-                                % (schema, path))
+                yield cls._fail("Unrecognized schema version {0!s} in {1!s}".format(schema, path))
                 return
 
             success = True
 
             # Do not generate 1000 failing tests for not yet updated repos
             if schema != '3.0.0':
-                stream.write("skipping (schema version %s)"
-                             % data['schema_version'])
+                stream.write("skipping (schema version {0!s})".format(data['schema_version']))
                 cls.skipped_repositories[schema] += 1
                 return
             else:
@@ -639,7 +637,7 @@ class TestContainer(object):
                 if 'releases' in package:
                     for release in package['releases']:
                         (yield cls._test_release,
-                            ("%s (%s)" % (package_name, path),
+                            ("{0!s} ({1!s})".format(package_name, path),
                              release, False, False))
         if 'includes' in data:
             for include in data['includes']:
@@ -695,7 +693,7 @@ class DefaultChannelTests(TestContainer, unittest.TestCase):
     def tearDownClass(cls):
         if cls.skipped_repositories:
             # TODO somehow pass stream here
-            print("Repositories skipped: %s" % dict(cls.skipped_repositories))
+            print("Repositories skipped: {0!s}".format(dict(cls.skipped_repositories)))
 
     def test_channel_keys(self):
         keys = sorted(self.j.keys())
@@ -732,7 +730,7 @@ class DefaultChannelTests(TestContainer, unittest.TestCase):
             if repository.startswith('.'):
                 continue
             if not repository.startswith("http"):
-                cls._fail("Unexpected repository url: %s" % repository)
+                cls._fail("Unexpected repository url: {0!s}".format(repository))
 
             for test in cls._include_tests(repository, stream):
                 yield test
@@ -781,7 +779,7 @@ class DefaultRepositoryTests(TestContainer, unittest.TestCase):
                     contents = f.read().decode('utf-8', 'strict')
                 data = json.loads(contents)
             except Exception as e:
-                yield cls._fail("strict while reading %r" % include, e)
+                yield cls._fail("strict while reading {0!r}".format(include), e)
                 continue
 
             # `include` is for output during tests only
@@ -797,7 +795,7 @@ class DefaultRepositoryTests(TestContainer, unittest.TestCase):
                 if 'releases' in package:
                     for release in package['releases']:
                         (yield cls._test_release,
-                            ("%s (%s)" % (package_name, include),
+                            ("{0!s} ({1!s})".format(package_name, include),
                              release,
                              False))
 
@@ -812,7 +810,7 @@ class DefaultRepositoryTests(TestContainer, unittest.TestCase):
                     if 'releases' in dependency:
                         for release in dependency['releases']:
                             (yield cls._test_release,
-                                ("%s (%s)" % (dependency_name, include),
+                                ("{0!s} ({1!s})".format(dependency_name, include),
                                  release,
                                  True))
 

--- a/tests/unittest_compat.py
+++ b/tests/unittest_compat.py
@@ -14,14 +14,14 @@ def inject_into_unittest():
                 """Just like self.assertTrue(a in b), but with a nicer default message."""
                 if member not in container:
                     if not msg:
-                        msg = '%r not found in %r' % (member, container)
+                        msg = '{0!r} not found in {1!r}'.format(member, container)
                     self.fail(msg)
 
             def assertNotIn(self, member, container, msg=None):
                 """Just like self.assertTrue(a not in b), but with a nicer default message."""
                 if member in container:
                     if not msg:
-                        msg = '%s unexpectedly found in %s' % (member,
+                        msg = '{0!s} unexpectedly found in {1!s}'.format(member,
                                                                container)
                     self.fail(msg)
 
@@ -29,7 +29,7 @@ def inject_into_unittest():
                 """Just like self.assertTrue(a > b), but with a nicer default message."""
                 if not a > b:
                     if not msg:
-                        msg = '%s not greater than %s' % (a, b)
+                        msg = '{0!s} not greater than {1!s}'.format(a, b)
                     self.fail(msg)
 
             def assertRegex(self, text, expected_regexp, msg=None):
@@ -38,7 +38,7 @@ def inject_into_unittest():
                     expected_regexp = re.compile(expected_regexp)
                 if not expected_regexp.search(text):
                     msg = msg or "Regexp didn't match"
-                    msg = '%s: %r not found in %r' % (msg, expected_regexp.pattern, text)
+                    msg = '{0!s}: {1!r} not found in {2!r}'.format(msg, expected_regexp.pattern, text)
                     raise self.failureException(msg)
 
             def assertNotRegex(self, text, unexpected_regexp, msg=None):
@@ -48,7 +48,7 @@ def inject_into_unittest():
                 match = unexpected_regexp.search(text)
                 if match:
                     msg = msg or "Regexp matched"
-                    msg = '%s: %r matches %r in %r' % (msg,
+                    msg = '{0!s}: {1!r} matches {2!r} in {3!r}'.format(msg,
                                                        text[match.start():match.end()],
                                                        unexpected_regexp.pattern,
                                                        text)
@@ -59,7 +59,7 @@ def inject_into_unittest():
                 default message."""
                 if not isinstance(obj, cls):
                     if not msg:
-                        msg = '%s is not an instance of %r' % (obj, cls)
+                        msg = '{0!s} is not an instance of {1!r}'.format(obj, cls)
                     self.fail(msg)
 
         unittest.TestCase = PatchedTestCase

--- a/utils/migrator.py
+++ b/utils/migrator.py
@@ -33,7 +33,7 @@ with open(old_repositories_json_path, encoding='utf-8') as of:
     for repository in old_data['repositories']:
         user_match = re.match('https://github.com/([^/]+)$', repository)
         if user_match:
-            api_url = 'https://api.github.com/users/%s/repos?per_page=100&%s' % (user_match.group(1), client_auth)
+            api_url = 'https://api.github.com/users/{0!s}/repos?per_page=100&{1!s}'.format(user_match.group(1), client_auth)
             json_string = urlopen(api_url).read()
             data = json.loads(str(json_string, encoding='utf-8'))
             for repo in data:
@@ -701,9 +701,9 @@ with open(old_repositories_json_path, encoding='utf-8') as of:
             entry['details'] = repository
 
             if repo_match.group(1).lower() == 'github.com':
-                release_url = 'https://github.com/%s/%s/tree/%s' % (repo_match.group(2), repo_match.group(3), branch)
+                release_url = 'https://github.com/{0!s}/{1!s}/tree/{2!s}'.format(repo_match.group(2), repo_match.group(3), branch)
             else:
-                release_url = 'https://bitbucket.org/%s/%s/src/%s' % (repo_match.group(2), repo_match.group(3), branch)
+                release_url = 'https://bitbucket.org/{0!s}/{1!s}/src/{2!s}'.format(repo_match.group(2), repo_match.group(3), branch)
             entry['releases'] = [
                 OrderedDict([
                     ('sublime_text', compatible_version),
@@ -713,9 +713,9 @@ with open(old_repositories_json_path, encoding='utf-8') as of:
 
             if name in st3_with_branch:
                 if repo_match.group(1).lower() == 'github.com':
-                    release_url = 'https://github.com/%s/%s/tree/%s' % (repo_match.group(2), repo_match.group(3), st3_with_branch[name])
+                    release_url = 'https://github.com/{0!s}/{1!s}/tree/{2!s}'.format(repo_match.group(2), repo_match.group(3), st3_with_branch[name])
                 else:
-                    release_url = 'https://bitbucket.org/%s/%s/src/%s' % (repo_match.group(2), repo_match.group(3), st3_with_branch[name])
+                    release_url = 'https://bitbucket.org/{0!s}/{1!s}/src/{2!s}'.format(repo_match.group(2), repo_match.group(3), st3_with_branch[name])
                 entry['releases'].append(
                     OrderedDict([
                         ('sublime_text', '>=3000'),
@@ -742,7 +742,7 @@ if not os.path.exists(new_repository_subfolder_path):
     os.mkdir(new_repository_subfolder_path)
 
 for letter in names:
-    include_path = '%s%s.json' % (new_repository_subfolder_path, letter)
+    include_path = '{0!s}{1!s}.json'.format(new_repository_subfolder_path, letter)
     includes.append(include_path)
     sorted_names = sorted(names[letter], key=str.lower)
     sorted_packages = []

--- a/utils/non_python_packages.py
+++ b/utils/non_python_packages.py
@@ -169,7 +169,7 @@ with open(old_repositories_json_path, encoding='utf-8') as of:
     for repository in old_data['repositories']:
         user_match = re.match('https://github.com/([^/]+)$', repository)
         if user_match:
-            api_url = 'https://api.github.com/users/%s/repos?per_page=100&%s' % (user_match.group(1), client_auth)
+            api_url = 'https://api.github.com/users/{0!s}/repos?per_page=100&{1!s}'.format(user_match.group(1), client_auth)
             json_string = urlopen(api_url).read()
             requests += 1
             data = json.loads(str(json_string, encoding='utf-8'))
@@ -207,13 +207,13 @@ with open(old_repositories_json_path, encoding='utf-8') as of:
             success = False
             while not success:
                 try:
-                    branch_url = 'https://api.github.com/repos/%s/%s/branches/%s?%s' % (user, repo, branch, client_auth)
+                    branch_url = 'https://api.github.com/repos/{0!s}/{1!s}/branches/{2!s}?{3!s}'.format(user, repo, branch, client_auth)
                     requests += 1
                     json_string = urlopen(branch_url).read()
                     data = json.loads(str(json_string, encoding='utf-8'))
                     sha = data['commit']['sha']
 
-                    tree_url = 'https://api.github.com/repos/%s/%s/git/trees/%s?%s' % (user, repo, sha, client_auth)
+                    tree_url = 'https://api.github.com/repos/{0!s}/{1!s}/git/trees/{2!s}?{3!s}'.format(user, repo, sha, client_auth)
                     requests += 1
                     json_string = urlopen(tree_url).read()
                     data = json.loads(str(json_string, encoding='utf-8'))
@@ -221,7 +221,7 @@ with open(old_repositories_json_path, encoding='utf-8') as of:
                     success = True
                 except (HTTPError):
                     five_hundreds += 1
-                    print('Requests: %s, 500s: %s' % (requests, five_hundreds))
+                    print('Requests: {0!s}, 500s: {1!s}'.format(requests, five_hundreds))
                     pass
 
             has_python = False
@@ -231,9 +231,9 @@ with open(old_repositories_json_path, encoding='utf-8') as of:
                    break
 
             if not has_python:
-                print('No python: %s' % name)
+                print('No python: {0!s}'.format(name))
             else:
-                print('Yes python: %s' % name)
+                print('Yes python: {0!s}'.format(name))
 
             master_list.append(name)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:package_control_channel?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:package_control_channel?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
